### PR TITLE
chore: Use heading instead of bold

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,12 +1,12 @@
-**Linked Ticket:**
+### Linked Ticket:
 
 *Link to the associated Linear ticket, if applicable*
 
-**Context:**
+### Context:
 
 *A brief explanation of the motivation for making the change*
 
-**Type of Change:**
+### Type of Change:
  - [ ] Bugfix
  - [ ] Adding functionality- non-breaking
  - [ ] Adding/updating functionality - potentially breaking
@@ -15,22 +15,22 @@
  - [ ] Documentation
  - [ ] Other (please describe)
 
-**Changes:**
+### Changes:
 
 *A brief description of what has been changed in this PR.*
 
-**Description of testing:**
+### Description of testing:
 
 *What testing activities have been carried out to prove this change will work? eg adding unit/integration/end-to-end tests, testing manually etc.* 
 
-**Does this change require an update to documentation/change log/structurizr?**
+### Does this change require an update to documentation/change log/structurizr?
 
 *Outline any changes required if applicable.*
 
-**What steps are needed to revert this change if required?**
+### What steps are needed to revert this change if required?
 
 *Is anything else required other than reverting the repository to before the PR was merged?*
 
-**Are there any other activities required to launch this release?**
+### Are there any other activities required to launch this release?
 
 *Anything else required other than merging the PR to launch- eg DB migrations, OPA/Authz associated changes etc.*


### PR DESCRIPTION
To simplify editing the template on new PRs